### PR TITLE
Bug Fix, New Method in ThreadSafeSet, and Modified Argument in scrape_website()

### DIFF
--- a/scrape_test.py
+++ b/scrape_test.py
@@ -6,12 +6,9 @@ import os
 from web_crawler import scrape_website
 
 
-def force_to_stop():
-    if os.path.isfile("yahoonews.jsonl"):
-        with open("yahoonews.jsonl", "r", encoding="utf-8") as f:
-            lines = f.readlines()
-            if len(lines) >= 30:
-                return True
+def force_to_stop(url, depth, visited):
+    if visited and len(visited) >= 50:
+        return True
     return False
 
 def write_to_file(page_content, source, status_code, is_success):


### PR DESCRIPTION
- Fixed a bug in the `scrape_website()` function caused by a missing `return` statement
- Added a `__len__()` method to the `ThreadSafeSet` class to return the length of the set
- Modified the `scrape_website()` function to include an additional argument for `stop_handler()`