### PR TITLE
feat: optional Playwright rendering for JS-driven pages (adapter, flag, playwright test script)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ def only_article_links(page: ScrapedPage) -> list[str]:
 
 You can optionally fetch “rendered” HTML using Playwright, which helps with SPA/JS-heavy pages. This is an additive feature: the default `aiohttp`-based crawler continues to work as-is. Playwright is only needed when you explicitly use it.
 
-- No lxml is used; BeautifulSoup runs with the built-in `html.parser`.
 - Playwright and a browser runtime (e.g., Chromium) are optional dependencies.
 
 ### Install (only if you use Playwright)

--- a/playwright_adapter.py
+++ b/playwright_adapter.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, List, Optional, Callable
+
+from bs4 import BeautifulSoup
+from email.utils import parsedate_to_datetime
+from datetime import datetime
+from urllib.parse import urljoin, urlparse
+
+# Reuse existing types and functions from web_crawler.py
+from web_crawler import (
+    ScrapedPage,
+    extract_page_text,
+    DEFAULT_USER_AGENT,
+)
+
+
+def _parse_last_modified(headers: Dict[str, str]) -> Optional[datetime]:
+    lm = headers.get("last-modified") or headers.get("Last-Modified")
+    if not lm:
+        return None
+    try:
+        return parsedate_to_datetime(lm)
+    except Exception:
+        return None
+
+
+def _resolve_links(soup: BeautifulSoup, base_url: str) -> List[str]:
+    """
+    Extract a[href] and resolve to absolute URLs, keeping only http/https.
+    """
+    out: List[str] = []
+    for a in soup.find_all("a", href=True):
+        href = a.get("href", "").strip()
+        if not href:
+            continue
+        abs_url = urljoin(base_url, href)
+        scheme = urlparse(abs_url).scheme
+        if scheme in ("http", "https"):
+            out.append(abs_url)
+    # De-dup while preserving order
+    return list(dict.fromkeys(out))
+
+
+async def fetch_html_with_playwright(
+    url: str,
+    user_agent: str = DEFAULT_USER_AGENT,
+    wait_until: str = "networkidle",  # "load" | "domcontentloaded" | "networkidle" | "commit"
+    timeout_ms: int = 30000,
+    headless: bool = True,
+    extra_headers: Optional[Dict[str, str]] = None,
+    wait_for_selector: Optional[str] = None,
+) -> Dict:
+    """
+    Navigate to the URL with Playwright and return HTML and response info.
+    """
+    try:
+        from playwright.async_api import async_playwright, TimeoutError as PlaywrightTimeoutError  # lazy import
+    except ImportError as e:
+        raise RuntimeError(
+            "Playwright is required when using the Playwright path. "
+            "Please run: pip install playwright && playwright install chromium"
+        ) from e
+
+    async with async_playwright() as p:
+        browser = None
+        context = None
+        page = None
+        try:
+            try:
+                browser = await p.chromium.launch(headless=headless)
+            except Exception as e:
+                raise RuntimeError(
+                    "Chromium not found. Please run: playwright install chromium"
+                ) from e
+
+            context = await browser.new_context(
+                user_agent=user_agent,
+                extra_http_headers=extra_headers or {},
+            )
+            page = await context.new_page()
+
+            resp = await page.goto(url, wait_until=wait_until, timeout=timeout_ms)
+
+            if wait_for_selector:
+                try:
+                    await page.wait_for_selector(wait_for_selector, timeout=timeout_ms)
+                except PlaywrightTimeoutError:
+                    pass
+
+            html = await page.content()
+            title = await page.title()
+
+            status = resp.status if resp else 0
+            headers = resp.headers if resp else {}
+
+            return {
+                "html": html,
+                "status": status,
+                "headers": headers,
+                "title": title,
+            }
+        finally:
+            try:
+                if page:
+                    await page.close()
+            except Exception:
+                pass
+            try:
+                if context:
+                    await context.close()
+            except Exception:
+                pass
+            try:
+                if browser:
+                    await browser.close()
+            except Exception:
+                pass
+
+
+async def crawl_url_with_playwright(
+    url: str,
+    user_agent: str = DEFAULT_USER_AGENT,
+    link_extractor: Optional[Callable[[ScrapedPage], List[str]]] = None,
+    wait_until: str = "networkidle",
+    timeout_ms: int = 30000,
+    headless: bool = True,
+    extra_headers: Optional[Dict[str, str]] = None,
+    wait_for_selector: Optional[str] = None,
+) -> ScrapedPage:
+    """
+    Render a single URL with Playwright and build a ScrapedPage.
+    """
+    fetched = await fetch_html_with_playwright(
+        url=url,
+        user_agent=user_agent,
+        wait_until=wait_until,
+        timeout_ms=timeout_ms,
+        headless=headless,
+        extra_headers=extra_headers,
+        wait_for_selector=wait_for_selector,
+    )
+
+    html: str = fetched["html"]
+    status: int = fetched["status"]
+    headers: Dict[str, str] = fetched["headers"]
+    title: Optional[str] = fetched["title"]
+
+    soup = BeautifulSoup(html, "html.parser")
+    text = extract_page_text(soup)
+
+    page = ScrapedPage(
+        url=url,
+        status=status,
+        success=bool(status) and 200 <= status < 400,
+        html=html,
+        text=text,
+        soup=soup,
+        headers=headers,
+        last_modified=_parse_last_modified(headers),
+        title=title,
+        links=[],
+    )
+
+    # Resolve links
+    if link_extractor is not None:
+        links = link_extractor(page)
+    else:
+        try:
+            from web_crawler import default_link_extractor as _default_link_extractor  # type: ignore
+            links = _default_link_extractor(page)
+        except Exception:
+            links = _resolve_links(soup, url)
+
+    page.links = links
+    return page
+
+
+# Demo: python playwright_adapter.py https://example.com
+if __name__ == "__main__":
+    import sys
+
+    async def _main():
+        target = sys.argv[1] if len(sys.argv) > 1 else "https://example.com"
+        page = await crawl_url_with_playwright(
+            target,
+            wait_until="networkidle",
+            wait_for_selector=None,
+        )
+        print("URL:", page.url)
+        print("Status:", page.status)
+        print("Title:", page.title)
+        print("Links:", len(page.links))
+        print("Text sample:", (page.text[:200] + "...") if page.text else "")
+
+    asyncio.run(_main())

--- a/requirements-playwright.txt
+++ b/requirements-playwright.txt
@@ -1,0 +1,2 @@
+playwright>=1.46.0
+beautifulsoup4>=4.12,<5

--- a/scrape_test_playwright.py
+++ b/scrape_test_playwright.py
@@ -1,0 +1,56 @@
+import asyncio
+from datetime import datetime, timedelta, timezone
+import json
+
+from web_crawler import scrape_website, ScrapedPage, DEFAULT_USER_AGENT
+
+
+def force_to_stop(url, depth, visited):
+    # same logic as scrape_test.py: stop after visiting 50 pages
+    return bool(visited and len(visited) >= 50)
+
+
+def write_to_file(page: ScrapedPage) -> bool:
+    # store as JSONL (separate file name for Playwright run)
+    record = {
+        "title": page.title,
+        "page_content": page.text,
+        "source": page.url,
+        "status_code": page.status,
+        "is_success": page.success,
+        "last_modified": page.last_modified.isoformat() if page.last_modified else None,
+        "links": page.links,
+        # "headers": page.headers,  # optional include if needed
+    }
+    with open("yahoonews_playwright.jsonl", "a", encoding="utf-8") as f:
+        json.dump(record, f, ensure_ascii=False)
+        f.write("\n")
+    return True
+
+
+async def scrape_yahoonews_playwright():
+    url = "https://news.yahoo.co.jp/"
+    # URL must be modified within the last 2 days (same as scrape_test.py)
+    since = datetime.now(timezone.utc) - timedelta(days=2)
+    url_regex = r"https://news\.yahoo\.co\.jp/articles/[^/]+/?$"
+
+    # Use Playwright route by setting use_playwright=True
+    await scrape_website(
+        url=url,
+        data_handler=write_to_file,
+        stop_handler=force_to_stop,
+        since=since,
+        url_regex=url_regex,
+        user_agent=DEFAULT_USER_AGENT,
+        use_playwright=True,
+        playwright_options={
+            "wait_until": "networkidle",   # "load" | "domcontentloaded" | "networkidle" | "commit"
+            "timeout_ms": 30000,
+            "headless": True,
+            # "wait_for_selector": "article"  # set if you need to wait for a specific element
+        },
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(scrape_yahoonews_playwright())


### PR DESCRIPTION
## Summary
Introduce an optional Playwright-based rendering path to support JavaScript-dependent / SPA pages while preserving the existing aiohttp-only crawler behavior as the default. No breaking changes to existing public function signatures (only additive optional parameters).

## Key Changes
- Added `use_playwright` (default: False) and `playwright_options` (dict) to `scrape_website`.
- Conditional branch: when `use_playwright=True`, a rendered HTML snapshot is obtained via headless Chromium before building `ScrapedPage`.
- Graceful fallback: if Playwright or Chromium is not installed (ImportError / RuntimeError), the code silently falls back to the existing aiohttp path.

## New Files
- `playwright_adapter.py`: Async adapter to render a single page with Playwright and return a populated `ScrapedPage`.
- `scrape_test_playwright.py`: Parallel to the existing `scrape_test.py`, demonstrating Yahoo News crawl using the Playwright path.
- `requirements-playwright.txt`: Optional dependency list for users who want JS rendering.

## Modified Files
- `web_crawler.py`: Minimal additive changes (new optional params and a Playwright branch).
- `README.md`: Added a section documenting optional Playwright usage and setup.

## Usage (Playwright Path)
```python
await scrape_website(
    url="https://example.com",
    data_handler=your_handler,
    use_playwright=True,
    playwright_options={
        "wait_until": "networkidle",   # or: "domcontentloaded", "load", "commit"
        "timeout_ms": 30000,
        "headless": True,
        # "wait_for_selector": "article"  # optional stabilization
    },
)